### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -4,7 +4,7 @@ JsonHashTable	KEYWORD1
 getArray	KEYWORD2
 getBool	KEYWORD2
 getDouble	KEYWORD2
-getHashTableKEYWORD2
+getHashTable	KEYWORD2
 getLong	KEYWORD2
 parseArray	KEYWORD2
 parseHashTable	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords